### PR TITLE
Deprecate v1 SDK → point to idanalyzer2 (npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 
+> # ⚠️ DEPRECATED — use the v2 SDK
+> This is the legacy **API v1** Node.js SDK (npm package `idanalyzer`). It targets the
+> older `api.idanalyzer.com` fleet and is no longer actively maintained.
+>
+> **New projects should use the API v2 SDK:**
+> [`idanalyzer2`](https://www.npmjs.com/package/idanalyzer2) ·
+> repo [idanalyzer/id-analyzer-v2-nodejs](https://github.com/idanalyzer/id-analyzer-v2-nodejs)
+> (`npm install idanalyzer2`).
+
 # ID Analyzer NodeJS
 This is a Javascript library for [ID Analyzer Identity Verification APIs](https://www.idanalyzer.com), though all the APIs can be called with without the library using simple HTTP requests as outlined in the [documentation](https://developer.idanalyzer.com), you can use this library to accelerate server-side development.
 


### PR DESCRIPTION
Adds a **DEPRECATED** banner to the README pointing new users to the **API v2** SDK (idanalyzer2 (npm)).

This v1 SDK targets the legacy `api.idanalyzer.com` fleet and is no longer actively maintained. README-only change.

Follow-ups (need registry credentials / your action): registry-level deprecation (npm deprecate / PyPI 'inactive' classifier / Packagist abandoned / NuGet deprecate) and archiving this GitHub repo after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)