### PR TITLE
docs: refresh README (drop architecture wording), add OIDC publish workflow, bump 1.2.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to npm
+
+# Publishes the legacy v1 package `idanalyzer` to npm when a version tag (v*) is pushed.
+# Uses npm Trusted Publishing (OIDC) — no NPM_TOKEN secret required.
+# Configure the trusted publisher on npmjs.com for package `idanalyzer`:
+# Publisher=GitHub Actions, Org=idanalyzer, Repo=id-analyzer-nodejs,
+# Workflow=publish.yml, Environment=(blank).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write   # required for OIDC trusted publishing + provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing requires npm >= 11.5.1
+      - run: npm install -g npm@latest
+
+      - name: Publish (skip if version already exists)
+        run: |
+          VER=$(node -p "require('./package.json').version")
+          if npm view "idanalyzer@${VER}" version >/dev/null 2>&1; then
+            echo "idanalyzer@${VER} already published — skipping."
+          else
+            npm publish --provenance --access public
+          fi

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 > # ⚠️ DEPRECATED — use the v2 SDK
 > This is the legacy **API v1** Node.js SDK (npm package `idanalyzer`). It targets the
-> older `api.idanalyzer.com` fleet and is no longer actively maintained.
+> older `api.idanalyzer.com` endpoint and is no longer actively maintained.
 >
 > **New projects should use the API v2 SDK:**
 > [`idanalyzer2`](https://www.npmjs.com/package/idanalyzer2) ·

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idanalyzer",
-  "version": "1.2.6",
+  "version": "1.2.8",
   "description": "ID Analyzer API client library, scan and verify global passport, driver license and identification card.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Refresh the npm README (deprecation banner already present; removed 'fleet' wording), add npm OIDC trusted-publishing workflow, bump to 1.2.8 so the registry page picks up the README. No functional changes.